### PR TITLE
Adicionando checagem de qualidade de código via CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,35 @@
+on: [push, pull_request]
+
+name: Code Quality
+
+jobs:
+  code-quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Copy files from repo
+        uses: actions/checkout@v4
+      
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry config virtualenvs.create false
+      
+      - name: Install dependencies
+        run: poetry install
+      
+      - name: Run Ruff
+        run: poetry run ruff check .; poetry run ruff check . --diff
+    
+      - name: Run Radon
+        run: poetry run radon cc ./app -a -na
+    
+      - name: Run Bandit
+        run: poetry run bandit -r ./app


### PR DESCRIPTION
Este PR configura as ferramentas que serão executadas pelo GitHub toda vez que um push for feito para o `upstream` ou quando um pull request for aberto.

As ferramentas configuradas foram as seguintes:

- [`Ruff`](https://docs.astral.sh/ruff/) - linter e formatador de código.
- [`Radon`](https://github.com/rubik/radon) - verifica se o código está muito complexo ou incoerente.
- [`Bandit`](https://bandit.readthedocs.io/en/latest/) - verifica possiveis falhas de segurança no código.